### PR TITLE
Authorization middleware added

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start-dev": "NODE_ENV='development' npm run build-client-watch & npm run start-server",
     "start-server": "nodemon server -e html,js,scss --ignore public --ignore client",
     "test": "NODE_ENV='test' mocha ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js --require @babel/polyfill --require @babel/register",
-    "test-watch": "NODE_ENV='test' mocha -w ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js ./client/**/**/*.spec.js --require @babel/register"
+    "test-watch": "NODE_ENV='test' mocha -w ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js ./client/**/**/*.spec.js --require @babel/polyfill --require @babel/register"
   },
   "author": "Fullstack Academy of Code",
   "license": "MIT",

--- a/server/api/authorization.js
+++ b/server/api/authorization.js
@@ -1,4 +1,5 @@
 const adminOnly = (req, res, next) => {
+  console.log(`Attempting to authorize admin`)
   if (!req.user || !req.user.isAdmin) {
     res.status(401)
     throw new Error(`Unauthorized attempt to access ${req.originalUrl} by non admin.`)

--- a/server/api/authorization.js
+++ b/server/api/authorization.js
@@ -1,0 +1,18 @@
+const adminOnly = (req, res, next) => {
+  if (!req.user || !req.user.isAdmin) {
+    res.status(401)
+    throw new Error(`Unauthorized attempt to access ${req.originalUrl} by non admin.`)
+  }
+}
+
+const usersOnly = (req, res, next) => {
+  if (!req.user || !req.user.id) {
+    res.status(401)
+    throw new Error(`Unauthorized attempt to access ${req.originalUrl} by non user`)
+  }
+}
+
+module.exports = {
+  adminOnly,
+  usersOnly
+}

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -1,6 +1,10 @@
 const router = require('express').Router()
-const {User} = require('../db/models')
+const { User } = require('../db/models')
+const { adminOnly } = require('./authorization')
+
 module.exports = router
+
+router.use('/', adminOnly)
 
 router.get('/', (req, res, next) => {
   User.findAll({

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -4,8 +4,6 @@ const { adminOnly } = require('./authorization')
 
 module.exports = router
 
-router.use('/', adminOnly)
-
 router.get('/', (req, res, next) => {
   User.findAll({
     // explicitly select only the id and email fields - even though
@@ -30,7 +28,7 @@ router.put('/:id', (req, res, next) => {
     .catch(next)
 })
 
-router.delete('/:id', (req, res, next) => {
+router.delete('/:id', adminOnly, (req, res, next) => {
   User.findById(req.params.id)
     .then(user => user.destroy())
     .then(updatedUser => res.status(200).json(updatedUser))

--- a/server/api/users.spec.js
+++ b/server/api/users.spec.js
@@ -36,8 +36,8 @@ describe('User routes', () => {
 
     beforeEach('create some users', (done) => {
       Promise.all([
-        User.create({ email: 'cody@email.com', password: '123' }),
-        User.create({ email: 'murphy@email.com', password: '123' })
+        User.create({ email: 'cody@email.com', password: '123', isAdmin: true }),
+        User.create({ email: 'murphy@email.com', password: '123' }),
       ])
       .then(users => {
         user = users[0]

--- a/server/index.js
+++ b/server/index.js
@@ -77,8 +77,8 @@ const createApp = () => {
 
   // error handling endware
   app.use((err, req, res, next) => {
-    console.error(err)
-    console.error(err.stack)
+    console.error(err.message)
+    if (res.statusCode !== 401) console.error(err.stack)
     res.status(err.status || 500).send(err.message || 'Internal server error.')
   })
 }


### PR DESCRIPTION
New middleware created. 

As a developer, I want to have middleware available to use in the api routers which restrict access to routes to admins only. Additional methods should be available to restrict api routes to logged in users only.

- [x] Write middleware for verifying if a user is logged in and is an Admin
- [x] Verify that the middleware can be used to restrict an entire router
- [x] Verify that it can be used in a single route to restrict access to just that route

Please note: We will need to figure out better tests on Monday. If we use the middleware on our current admin routes it can break the tests since the tests are using the api without being logged in. We should have tests in the end that test both possibilities, that logged in admins can use the api, while regular users and guests cannot.
